### PR TITLE
414 API Aufstellungen Fix

### DIFF
--- a/backend/endpoints/api/controller.js
+++ b/backend/endpoints/api/controller.js
@@ -14,8 +14,8 @@ async function setAufstellung(req, authentication) {
     const termin = req.body.body.terminId;
     const data = req.body.body.aufstellungen;
 
-    const stmt = 'SELECT count(*) AS count FROM termine WHERE termine.id = ?';
-    const terminExists = await _db.queryV(stmt, [terminId]);
+    const stmt = 'SELECT count(*) AS count FROM Termine WHERE id = ?';
+    const terminExists = await _db.queryV(stmt, [termin]);
     if (terminExists[0].count === 0) return [];
 
     const role = await _roles.getRoleForTermin(authentication, termin);
@@ -26,17 +26,27 @@ async function setAufstellung(req, authentication) {
         if (boss.aufstellungId == null)
         {
             if (boss.bossId == null) continue;
-            await _termin.addBoss(termin, boss.bossId).then(function(res) {
+            try {
+                let res = await _termin.addBoss(termin, boss.bossId);
                 aufstellung = res.insertId;
-                if (boss.isCM === true || boss.isCM === false) {
+            }
+            catch (e) {
+                //Unable to insert, next boss
+                continue;
+            }
+            if (boss.isCM === true || boss.isCM === false) {
+                try {
                     await _aufstellung.setCM(aufstellung, boss.isCM);
                 }
-            })
+                catch (e) {
+                    //Ignore not possible to set CM.
+                }
+            }
         }
         else
         {
-            const stmt2 = 'SELECT count(*) AS count FROM Aufstellung id = ? and fk_termin = ?';
-            const aufstellungTerminExists = await _db.queryV(stmt2, [aufstellung, terminId]);
+            const stmt2 = 'SELECT count(*) AS count FROM Aufstellung WHERE (id = ?) and (fk_termin = ?)';
+            const aufstellungTerminExists = await _db.queryV(stmt2, [aufstellung, termin]);
             if (aufstellungTerminExists[0].count === 0) continue;
         }
         if (aufstellung == null) continue;
@@ -46,9 +56,19 @@ async function setAufstellung(req, authentication) {
         }
         for (player of boss.positionen) {
             if (1 <= player.position && player.position <= 10) {
-                await _element.setClass(aufstellung, player.position, player.classId);
-                await _element.setRole(aufstellung, player.position, player.roleId);
-                await _element.setName(aufstellung, player.position, player.spielerId);
+                const pos = player.position;
+                const classId = player.classId;
+                const roleId = player.roleId;
+                const playerId = player.spielerId;
+
+                const stmt3 = 'INSERT INTO AufstellungElement (fk_aufstellung, position, fk_class, fk_role, fk_spieler) VALUES (?,?,?,?,?) ON DUPLICATE KEY UPDATE fk_class = ?, fk_role = ?, fk_spieler = ?';
+                try {
+                    await _db.queryV(stmt3, [aufstellung, pos, classId, roleId, playerId, classId, roleId, playerId]);
+                }
+                catch (e) {
+                    // Ignore, next element
+                    continue;
+                }
             }
         }
     }

--- a/backend/endpoints/api/controller.js
+++ b/backend/endpoints/api/controller.js
@@ -14,16 +14,22 @@ async function setAufstellung(req, authentication) {
 
     const stmt = 'SELECT count(*) AS count FROM Termin WHERE id = ?';
     const terminExists = await _db.queryV(stmt, [termin]);
-    if (terminExists[0].count === 0) return [];
+    if (terminExists[0].count === 0) {
+        return [];
+    }
 
     const role = await _roles.getRoleForTermin(authentication, termin);
-    if (role <= 0) return [];
+    if (role <= 0) {
+        return [];
+    }
 
     for (boss of data) {
         let aufstellung = boss.aufstellungId;
         if (boss.aufstellungId == null)
         {
-            if (boss.bossId == null) continue;
+            if (boss.bossId == null) {
+                continue;
+            }
             try {
                 let res = await _termin.addBoss(termin, boss.bossId);
                 aufstellung = res.insertId;
@@ -45,9 +51,13 @@ async function setAufstellung(req, authentication) {
         {
             const stmt2 = 'SELECT count(*) AS count FROM Aufstellung WHERE (id = ?) and (fk_termin = ?)';
             const aufstellungTerminExists = await _db.queryV(stmt2, [aufstellung, termin]);
-            if (aufstellungTerminExists[0].count === 0) continue;
+            if (aufstellungTerminExists[0].count === 0) {
+                continue;
+            }
         }
-        if (aufstellung == null) continue;
+        if (aufstellung == null) {
+            continue;
+        }
 
         if (boss.success === true || boss.success === false) {
             await _aufstellung.setSuccess(aufstellung, boss.success);

--- a/backend/endpoints/api/controller.js
+++ b/backend/endpoints/api/controller.js
@@ -11,7 +11,7 @@ async function setAufstellung(req, authentication) {
     const termin = req.body.body.terminId;
     const data = req.body.body.aufstellungen;
 
-    if (!await _termin.doesTerminExist(termin)) {
+    if (!(await _termin.doesTerminExist(termin))) {
         return [];
     }
 

--- a/backend/endpoints/api/controller.js
+++ b/backend/endpoints/api/controller.js
@@ -15,7 +15,7 @@ async function setAufstellung(req, authentication) {
         return [];
     }
 
-    const role = await _roles.getRoleForTermin(authentication, termin);
+    const role = await _roles.forTermin(authentication, termin);
     if (!role || role <= 0) {
         return [];
     }

--- a/backend/endpoints/api/controller.js
+++ b/backend/endpoints/api/controller.js
@@ -15,8 +15,7 @@ async function setAufstellung(req, authentication) {
     const data = req.body.body.aufstellungen;
 
     const terminExists = await _db.queryV('SELECT count(*) AS count FROM termine WHERE termine.id = ?', [terminId])
-    if (terminExists.count === 0) return []; //Does not work as expected
-    // if terminExists is returned the client gets: {"count":0} as application/json if non existent termin
+    if (terminExists[0].count === 0) return [];
 
     const role = await _roles.getRoleForTermin(authentication, termin);
     if (role <= 0) return [];
@@ -27,7 +26,7 @@ async function setAufstellung(req, authentication) {
         {
             if (boss.bossId == null) continue;
             await _termin.addBoss(termin, boss.bossId).then(function(res) {
-                aufstellung = res.insertId // however here I can interact with the db return and accsess it (also converts to application/json if returned to the client)
+                aufstellung = res.insertId
                 if (boss.isCM === true || boss.isCM === false) {
                     await _aufstellung.setCM(aufstellung, boss.isCM);
                 }
@@ -35,8 +34,8 @@ async function setAufstellung(req, authentication) {
         }
         else
         {
-            const res = await _db.queryV('SELECT count(*) AS count FROM Aufstellung id = ? and fk_termin = ?', [aufstellung, terminId])
-            if (res.count <= 0) continue; // probably same issue here
+            const aufstellungTerminExists = await _db.queryV('SELECT count(*) AS count FROM Aufstellung id = ? and fk_termin = ?', [aufstellung, terminId])
+            if (aufstellungTerminExists[0].count === 0) continue;
         }
         if (aufstellung == null) continue;
 

--- a/backend/endpoints/api/controller.js
+++ b/backend/endpoints/api/controller.js
@@ -14,7 +14,7 @@ async function setAufstellung(req, authentication) {
     const termin = req.body.body.terminId;
     const data = req.body.body.aufstellungen;
 
-    const stmt = 'SELECT count(*) AS count FROM Termine WHERE id = ?';
+    const stmt = 'SELECT count(*) AS count FROM Termin WHERE id = ?';
     const terminExists = await _db.queryV(stmt, [termin]);
     if (terminExists[0].count === 0) return [];
 

--- a/backend/endpoints/api/controller.js
+++ b/backend/endpoints/api/controller.js
@@ -1,5 +1,4 @@
 const _aufstellung = require('../aufstellungen/aufstellung');
-const _element = require('../aufstellungen/element');
 const _roles = require('../../authentication/role');
 const _termin = require('../termine/termin');
 const _db = require('../../db/connector');
@@ -8,7 +7,6 @@ const { reduce } = require('../raids/controller');
 module.exports = [
     {function: setAufstellung, path: '/aufstellungen', method: 'post', authed: true},
 ];
-
 
 async function setAufstellung(req, authentication) {
     const termin = req.body.body.terminId;
@@ -67,7 +65,6 @@ async function setAufstellung(req, authentication) {
                 }
                 catch (e) {
                     // Ignore, next element
-                    continue;
                 }
             }
         }

--- a/backend/endpoints/api/controller.js
+++ b/backend/endpoints/api/controller.js
@@ -14,7 +14,8 @@ async function setAufstellung(req, authentication) {
     const termin = req.body.body.terminId;
     const data = req.body.body.aufstellungen;
 
-    const terminExists = await _db.queryV('SELECT count(*) AS count FROM termine WHERE termine.id = ?', [terminId])
+    const stmt = 'SELECT count(*) AS count FROM termine WHERE termine.id = ?';
+    const terminExists = await _db.queryV(stmt, [terminId]);
     if (terminExists[0].count === 0) return [];
 
     const role = await _roles.getRoleForTermin(authentication, termin);
@@ -26,7 +27,7 @@ async function setAufstellung(req, authentication) {
         {
             if (boss.bossId == null) continue;
             await _termin.addBoss(termin, boss.bossId).then(function(res) {
-                aufstellung = res.insertId
+                aufstellung = res.insertId;
                 if (boss.isCM === true || boss.isCM === false) {
                     await _aufstellung.setCM(aufstellung, boss.isCM);
                 }
@@ -34,7 +35,8 @@ async function setAufstellung(req, authentication) {
         }
         else
         {
-            const aufstellungTerminExists = await _db.queryV('SELECT count(*) AS count FROM Aufstellung id = ? and fk_termin = ?', [aufstellung, terminId])
+            const stmt2 = 'SELECT count(*) AS count FROM Aufstellung id = ? and fk_termin = ?';
+            const aufstellungTerminExists = await _db.queryV(stmt2, [aufstellung, terminId]);
             if (aufstellungTerminExists[0].count === 0) continue;
         }
         if (aufstellung == null) continue;

--- a/backend/endpoints/api/controller.js
+++ b/backend/endpoints/api/controller.js
@@ -2,31 +2,46 @@ const _aufstellung = require('../aufstellungen/aufstellung');
 const _element = require('../aufstellungen/element');
 const _roles = require('../../authentication/role');
 const _termin = require('../termine/termin');
+const _db = require('../../db/connector');
+const { reduce } = require('../raids/controller');
 
 module.exports = [
-    {function: setAufstellung, path: '/aufstellung', method: 'post', authed: true},
+    {function: setAufstellung, path: '/aufstellungen', method: 'post', authed: true},
 ];
 
 
 async function setAufstellung(req, authentication) {
-    const invalidData = "{\"error\":\"invalid data\"}";
-    
     const termin = req.body.body.terminId;
     const data = req.body.body.aufstellungen;
 
+    const terminExists = await _db.queryV('SELECT count(*) AS count FROM termine WHERE termine.id = ?', [terminId])
+    if (terminExists.count === 0) return []; //Does not work as expected
+    // if terminExists is returned the client gets: {"count":0} as application/json if non existent termin
+
     const role = await _roles.getRoleForTermin(authentication, termin);
-    if (role <= 0) return "{\"error\":\"no permission\"}";
+    if (role <= 0) return [];
 
     for (boss of data) {
         let aufstellung = boss.aufstellungId;
         if (boss.aufstellungId == null)
         {
             if (boss.bossId == null) continue;
-            const allBosses = await _termin.addBoss(termin, boss.bossId)
-            aufstellung = allBosses[allBosses.length - 1].id;
-            if (boss.isCM === true || boss.isCM === false) {
-                await _aufstellung.setCM(aufstellung, boss.isCM);
-            }
+            await _termin.addBoss(termin, boss.bossId).then(function(res) {
+                aufstellung = res.insertId // however here I can interact with the db return and accsess it (also converts to application/json if returned to the client)
+                if (boss.isCM === true || boss.isCM === false) {
+                    await _aufstellung.setCM(aufstellung, boss.isCM);
+                }
+            })
+        }
+        else
+        {
+            const res = await _db.queryV('SELECT count(*) AS count FROM Aufstellung id = ? and fk_termin = ?', [aufstellung, terminId])
+            if (res.count <= 0) continue; // probably same issue here
+        }
+        if (aufstellung == null) continue;
+
+        if (boss.success === true || boss.success === false) {
+            await _aufstellung.setSuccess(aufstellung, boss.success);
         }
         for (player of boss.positionen) {
             if (1 <= player.position && player.position <= 10) {
@@ -36,5 +51,6 @@ async function setAufstellung(req, authentication) {
             }
         }
     }
-    return "{\"status\":\"OK\"}";
+
+    return await _aufstellung.getForTermin(termin);
 }

--- a/backend/endpoints/aufstellungen/element.js
+++ b/backend/endpoints/aufstellungen/element.js
@@ -5,6 +5,7 @@ exports.getForAufstellung = getForAufstellung;
 exports.setClass = setClass;
 exports.setRole = setRole;
 exports.setName = setName;
+exports.setCompleteElement = setCompleteElement;
 
 async function getForTermin(termin) {
     const stmt = 'SELECT Aufstellung.id AS aufstellung, AufstellungElement.position AS pos, Klasse.abbr AS class, Rolle.abbr AS role, Spieler.id AS id, Spieler.name AS name, Spieler.accname AS accname FROM Aufstellung ' +
@@ -57,6 +58,16 @@ async function setName(aufstellung, position, name){
     try {
         return await db.queryV(stmt, [aufstellung, position, name, name]);
     } catch(e) {
+        throw e;
+    }
+}
+
+async function setCompleteElement(aufstellung, position, classId, roleId, playerId) {
+    const stmt = 'INSERT INTO AufstellungElement (fk_aufstellung, position, fk_class, fk_role, fk_spieler) VALUES (?,?,?,?,?) ON DUPLICATE KEY UPDATE fk_class = ?, fk_role = ?, fk_spieler = ?';
+    try {
+        return await db.queryV(stmt, [aufstellung, position, classId, roleId, playerId, classId, roleId, playerId]);
+    }
+    catch (e) {
         throw e;
     }
 }

--- a/backend/endpoints/termine/termin.js
+++ b/backend/endpoints/termine/termin.js
@@ -16,6 +16,7 @@ exports.setLocked = setLocked;
 exports.delete = deleteTermin;
 exports.getText = getText;
 exports.saveText = saveText;
+exports.doesTerminExist = doesTerminExist;
 
 async function isArchived(terminId) {
     const stmt = 'SELECT isArchived FROM Termin WHERE id = ?';
@@ -158,4 +159,10 @@ async function saveText(termin, text) {
     } catch(e) {
         throw e;
     }
+}
+
+async function doesTerminExist(termin) {
+    const stmt = 'SELECT count(*) AS count FROM Termin WHERE id = ?';
+    const terminExists = await db.queryV(stmt, [termin]);
+    return !(terminExists[0].count === 0);
 }


### PR DESCRIPTION
# API Aufstellungen Fix
Dieser Fix behebt für #414:
- einen Bug mit dem laden der ID einer neu erstellten Aufstellung
- dass die Aufstellungs ID wirklich zur Termin ID gehört und somit geändert werden darf
- reduzieren der Datenbankaufrufe von ~32 pro Boss zu 13 pro Boss
- erweitern um auch success/fail mit zu setzten